### PR TITLE
Improve runtime diagnostics and add audio interface

### DIFF
--- a/docs/web/index.html
+++ b/docs/web/index.html
@@ -17,6 +17,15 @@
     <label><input type="checkbox" id="js8"> JS8</label>
     <span id="status">Idle</span>
   </div>
+  <div id="debug">
+    Last capture: <span id="lastCapture">-</span>
+    Last decode: <span id="lastDecode">-</span>
+    Messages: <span id="lastCount">0</span>
+  </div>
+  <div>
+    <audio id="audio" controls></audio>
+    <button id="refreshAudio">Refresh Audio</button>
+  </div>
   <table id="messages">
     <thead>
       <tr><th>Time</th><th>Band</th><th>Mode</th><th>SNR</th><th>Text</th></tr>
@@ -31,7 +40,7 @@
       tbody.innerHTML = msgs.map(m =>
         `<tr><td>${new Date(m.timestamp*1000).toLocaleTimeString()}</td>` +
         `<td>${m.band}</td><td>${m.mode}</td>` +
-        `<td>${m.snr_db.toFixed(1)}</td><td>${m.text}</td></tr>`
+        `<td>${m.snr.toFixed(1)}</td><td>${m.text}</td></tr>`
       ).join('');
     }
     async function loadControls() {
@@ -47,18 +56,34 @@
       js8.checked = modeData.js8;
       js8.onchange = () => fetch(`/api/mode?js8=${js8.checked?1:0}`, {method:'POST'});
     }
+    async function loadStatus() {
+      const resp = await fetch('/api/status');
+      const s = await resp.json();
+      document.getElementById('lastCapture').textContent =
+        s.last_capture ? new Date(s.last_capture*1000).toLocaleTimeString() : '-';
+      document.getElementById('lastDecode').textContent =
+        s.last_decode ? new Date(s.last_decode*1000).toLocaleTimeString() : '-';
+      document.getElementById('lastCount').textContent = s.last_count;
+    }
     function setupEvents() {
       const status = document.getElementById('status');
       const evt = new EventSource('/events');
       evt.onmessage = () => {
         status.textContent = 'Decoding...';
         loadMessages();
-        setTimeout(() => status.textContent = 'Idle', 3000);
+        loadStatus();
+        setTimeout(() => status.textContent = 'Idle', 15000);
       };
       evt.onerror = () => { status.textContent = 'Disconnected'; };
     }
+    document.getElementById('refreshAudio').onclick = () => {
+      const a = document.getElementById('audio');
+      a.src = '/api/audio?ts=' + Date.now();
+      a.play();
+    };
     loadMessages();
     loadControls();
+    loadStatus();
     setupEvents();
   </script>
 </body>

--- a/include/web_server.hpp
+++ b/include/web_server.hpp
@@ -2,6 +2,7 @@
 #include "data_store.hpp"
 #include "rf_input.hpp"
 #include "dsp/engine.hpp"
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -14,11 +15,16 @@ class ApiHandler;
 class SseHandler;
 class BandHandler;
 class ModeHandler;
+class StatusHandler;
+class AudioHandler;
 
 class WebServer {
 public:
   WebServer(DataStore &db, RfInput &rf, DecodeEngine &engine,
-            const std::string &doc_root, int port = 8080);
+            std::atomic<std::time_t> &last_capture,
+            std::atomic<std::time_t> &last_decode,
+            std::atomic<size_t> &last_count, const std::string &doc_root,
+            int port = 8080);
   ~WebServer();
 
 private:
@@ -27,6 +33,8 @@ private:
   std::unique_ptr<SseHandler> sse_handler_;
   std::unique_ptr<BandHandler> band_handler_;
   std::unique_ptr<ModeHandler> mode_handler_;
+  std::unique_ptr<StatusHandler> status_handler_;
+  std::unique_ptr<AudioHandler> audio_handler_;
 };
 
 } // namespace hf


### PR DESCRIPTION
## Summary
- Keep hfdecoder running until SIGINT and log capture/decoder activity
- Expose `/api/status` and `/api/audio` endpoints with a web UI showing timestamps, decode counts, and audio playback
- Fix SNR display and expand dashboard for troubleshooting

## Testing
- `cmake -S . -B build -DBUILD_MAIN=ON`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68b274add2b08329888cbffecad05927